### PR TITLE
disambiguation for local formulas

### DIFF
--- a/css3-font-converter.rb
+++ b/css3-font-converter.rb
@@ -11,8 +11,8 @@ class Css3FontConverter < Formula
   depends_on "fontforge"
   depends_on "ttf2eot"
   depends_on "ttfautohint"
-  depends_on "woff2"
-  depends_on "sfnt2woff"
+  depends_on "folkloreatelier/fonts/woff2"
+  depends_on "folkloreatelier/fonts/sfnt2woff"
 
   def install
     bin.install Dir["*.sh"]


### PR DESCRIPTION
Without this change, the tap/install installation instruction will fail because woff2 has been added as a head-only package in the "official formulas" and now require disambiguation.
